### PR TITLE
fix glutter css - it is not select, overlap others

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -351,6 +351,7 @@ html, body {
 .gutter {
   background-color: var(--main-bg-color);
   flex: 0 0 auto;
+  z-index: 1;
 }
 .gutter.gutter-horizontal,
 .gutter.gutter-horizontal:hover {


### PR DESCRIPTION
When I maximize the editor's glutter, it overlaps with other components and cannot be reselected and resized.